### PR TITLE
Added query_id to SwapResponse type

### DIFF
--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -84,6 +84,7 @@ export interface SwapResponse {
     to: string;
     value: string;
     body: string;
+    query_id: string;
     init: {
         code: string;
         data: string;


### PR DESCRIPTION
This pull request includes a small change to the `src/types/swap.ts` file. The change adds a new property to the `SwapResponse` interface.

* [`src/types/swap.ts`](diffhunk://#diff-c0f4fecb306d1d20b323f616fb61ce84f69d95d80ca4c066a087852aa89fcf27R87): Added a `query_id` property to the `SwapResponse` interface.